### PR TITLE
Fix ssh credential reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Command "add" respects options "--ldap-only", "--slurm-only" and "--dirs-only" now.
+- User is only asked once for ssh credentials and not several times for Slurm and directory management respectively
 
 ## [0.1.0] - 2022-06-20
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
@@ -1005,6 +1005,7 @@ dependencies = [
  "ldap3",
  "log",
  "maplit",
+ "once_cell",
  "rpassword",
  "serde",
  "ssh2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = "0.9.0"
 ldap3 = "0.11.1"
 maplit = "1.0.2"
 ssh2 = "0.3.1"
+once_cell = "1.17.1"
 
 [package.metadata.deb]
 maintainer = "Dominik Wagner <dominik.wagner@th-nuernberg.de>"

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -4,38 +4,21 @@ pub mod dir {
     use ssh2::Session;
     use std::io::prelude::*;
     use std::net::TcpStream;
-    use util::io_util::user_input;
 
     use crate::config::config::MgmtConfig;
-    use crate::{util, Entity, Group};
+    use crate::ssh::SshCredential;
+    use crate::{Entity, Group};
 
-    pub fn add_user_directories(entity: &Entity, config: &MgmtConfig) {
-        let (username, password) = ask_credentials(&config.default_ssh_user);
+    pub fn add_user_directories(entity: &Entity, config: &MgmtConfig, credentials: &SshCredential) {
+        handle_compute_nodes(entity, config, credentials);
 
-        handle_compute_nodes(entity, config, &username, &password);
+        handle_nfs(entity, config, credentials);
 
-        handle_nfs(entity, config, &username, &password);
-
-        handle_home(entity, config, &username, &password);
-    }
-
-    fn ask_credentials(default_user: &str) -> (String, String) {
-        println!("Enter your SSH username (defaults to {}):", default_user);
-        let mut username = user_input();
-        if username.is_empty() {
-            username = default_user.to_string();
-        }
-        let password = rpassword::prompt_password("Enter your SSH password: ").unwrap();
-        (username, password)
+        handle_home(entity, config, credentials);
     }
 
     /// Establish SSH connection to each compute node, make user directory and set quota
-    fn handle_compute_nodes(
-        entity: &Entity,
-        config: &MgmtConfig,
-        ssh_username: &str,
-        ssh_password: &str,
-    ) {
+    fn handle_compute_nodes(entity: &Entity, config: &MgmtConfig, credentials: &SshCredential) {
         debug!("Start handling directories on compute nodes");
 
         if config.compute_nodes.is_empty() {
@@ -71,7 +54,8 @@ pub mod dir {
             let mut sess = Session::new().unwrap();
             sess.handshake(&tcp).unwrap();
 
-            sess.userauth_password(ssh_username, ssh_password).unwrap();
+            sess.userauth_password(credentials.username(), credentials.password())
+                .unwrap();
 
             // Create directory
             let directory = format!("{}/{}", config.compute_node_root_dir, entity.username);
@@ -119,7 +103,7 @@ pub mod dir {
     }
 
     /// Establish SSH connection to NFS host, make user directory and set quota
-    fn handle_nfs(entity: &Entity, config: &MgmtConfig, ssh_username: &str, ssh_password: &str) {
+    fn handle_nfs(entity: &Entity, config: &MgmtConfig, credentials: &SshCredential) {
         debug!("Start handling NFS user directory");
 
         if config.nfs_host.is_empty() {
@@ -146,7 +130,8 @@ pub mod dir {
         let mut sess = Session::new().unwrap();
         sess.handshake(&tcp).unwrap();
 
-        sess.userauth_password(ssh_username, ssh_password).unwrap();
+        sess.userauth_password(credentials.username(), credentials.password())
+            .unwrap();
 
         // Create directory
         let mut group_dir = "staff";
@@ -189,7 +174,7 @@ pub mod dir {
     }
 
     /// Establish SSH connection to home host, make user directory and set quota
-    fn handle_home(entity: &Entity, config: &MgmtConfig, ssh_username: &str, ssh_password: &str) {
+    fn handle_home(entity: &Entity, config: &MgmtConfig, credentials: &SshCredential) {
         debug!("Start handling home directory");
 
         if config.home_host.is_empty() {
@@ -212,7 +197,8 @@ pub mod dir {
         let mut sess = Session::new().unwrap();
         sess.handshake(&tcp).unwrap();
 
-        sess.userauth_password(ssh_username, ssh_password).unwrap();
+        sess.userauth_password(credentials.username(), credentials.password())
+            .unwrap();
 
         // Create directory
         let directory = format!("/home/{}", entity.username);

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,0 +1,13 @@
+use crate::util::io_util;
+mod ssh_credential;
+pub use ssh_credential::SshCredential;
+
+fn ask_credentials(default_user: &str) -> (String, String) {
+    println!("Enter your SSH username (defaults to {}):", default_user);
+    let mut username = io_util::user_input();
+    if username.is_empty() {
+        username = default_user.to_string();
+    }
+    let password = rpassword::prompt_password("Enter your SSH password: ").unwrap();
+    (username, password)
+}

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -2,8 +2,11 @@ use crate::util::io_util;
 mod ssh_credential;
 pub use ssh_credential::SshCredential;
 
-fn ask_credentials(default_user: &str) -> (String, String) {
+/// Asks user over the terminal for a username and password which are meant to be used for the
+/// authentication in a ssh connection
+fn ask_credentials_for_ssh(default_user: &str) -> (String, String) {
     println!("Enter your SSH username (defaults to {}):", default_user);
+
     let mut username = io_util::user_input();
     if username.is_empty() {
         username = default_user.to_string();

--- a/src/ssh/ssh_credential.rs
+++ b/src/ssh/ssh_credential.rs
@@ -1,0 +1,31 @@
+use once_cell::unsync::OnceCell;
+
+use crate::config::config::MgmtConfig;
+
+pub struct SshCredential<'a> {
+    default_ssh_user: &'a str,
+    username_password: OnceCell<(String, String)>,
+}
+
+impl<'a> SshCredential<'a> {
+    pub fn new(config: &'a MgmtConfig) -> Self {
+        Self {
+            username_password: OnceCell::new(),
+            default_ssh_user: &config.default_ssh_user,
+        }
+    }
+    pub fn username(&self) -> &str {
+        let (username, _) = self
+            .username_password
+            .get_or_init(|| super::ask_credentials(self.default_ssh_user));
+
+        username
+    }
+    pub fn password(&self) -> &str {
+        let (_, password) = self
+            .username_password
+            .get_or_init(|| super::ask_credentials(self.default_ssh_user));
+
+        password
+    }
+}

--- a/src/ssh/ssh_credential.rs
+++ b/src/ssh/ssh_credential.rs
@@ -2,6 +2,8 @@ use once_cell::unsync::OnceCell;
 
 use crate::config::config::MgmtConfig;
 
+/// Fetches username and password lazy at the first time.
+/// The fetching of username and password happens only once !
 pub struct SshCredential<'a> {
     default_ssh_user: &'a str,
     username_password: OnceCell<(String, String)>,
@@ -14,17 +16,18 @@ impl<'a> SshCredential<'a> {
             default_ssh_user: &config.default_ssh_user,
         }
     }
+    /// Returns given username of user or the default user name if the user has given no username
     pub fn username(&self) -> &str {
         let (username, _) = self
             .username_password
-            .get_or_init(|| super::ask_credentials(self.default_ssh_user));
+            .get_or_init(|| super::ask_credentials_for_ssh(self.default_ssh_user));
 
         username
     }
     pub fn password(&self) -> &str {
         let (_, password) = self
             .username_password
-            .get_or_init(|| super::ask_credentials(self.default_ssh_user));
+            .get_or_init(|| super::ask_credentials_for_ssh(self.default_ssh_user));
 
         password
     }


### PR DESCRIPTION
# Problem before this PR

For example If  user wants to add an user to Slurm db and wants manage its directory then he has to enter the ssh credentials twice. This relates to the issue #8 .

## Fix

Put asking for credentials, ssh connection, into one struct. It asks the user for username/password only once and only when the credentials are required the 1 time.

## Once Cell as new dependency 

This crate allows to initialize a field in a lazy way.  Since the field is only set once at the 1. time of access, its mutability is interior. Because of that , the struct SshCredentials can be passed immutably around the app.