### PR TITLE
Fix: no unclean aborting process on error for result anymore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,6 @@ dependencies = [
  "serde",
  "ssh2",
  "tempfile",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ maplit = "1.0.2"
 ssh2 = "0.9.4"
 once_cell = "1.17.1"
 anyhow = { version = "1.0.70", features = ["backtrace"] }
-thiserror = "1.0.40"
 
 [package.metadata.deb]
 maintainer = "Dominik Wagner <dominik.wagner@th-nuernberg.de>"
@@ -33,6 +32,14 @@ depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
-    ["target/release/usermgmt", "usr/bin/", "755"],
-    ["README.md", "usr/share/doc/usermgmt/README", "644"],
+    [
+        "target/release/usermgmt",
+        "usr/bin/",
+        "755",
+    ],
+    [
+        "README.md",
+        "usr/share/doc/usermgmt/README",
+        "644",
+    ],
 ]

--- a/src/app_error.rs
+++ b/src/app_error.rs
@@ -1,55 +1,19 @@
+use crate::prelude::*;
 use anyhow::anyhow;
-use std::{io, process::Output};
-use thiserror::Error;
+use std::process::Output;
 
-/// Error which is used in application. It contains a backstrace, an error message and an exit
-/// code. Most of the time it is used to report information to the user of this
-/// application in case of an error.
-#[derive(Debug, Error)]
-#[error("Error: {error:#?}.\nExit code: {exit_code}")]
-pub struct AppError {
-    #[source]
-    error: anyhow::Error,
-    exit_code: i32,
-}
-
-impl AppError {
-    pub fn new_with_exit_code(error: anyhow::Error, exit_code: i32) -> Self {
-        Self { error, exit_code }
-    }
-
-    /// Defaults to 1 for some error.
-    /// May return own defined exit code.
-    /// If the cause of this error is an io error, then it returns the os exit code of the io error.
-    pub fn exit_code(&self) -> i32 {
-        self.exit_code
-    }
-}
-
-impl From<anyhow::Error> for AppError {
-    fn from(value: anyhow::Error) -> Self {
-        match value.downcast_ref::<io::Error>() {
-            // Make sure that exit code is sync with os error.
-            Some(io_error) => Self {
-                exit_code: io_error.raw_os_error().unwrap_or(1),
-                error: value,
-            },
-            None => Self {
-                error: value,
-                exit_code: 1,
-            },
-        }
-    }
-}
-
-impl From<Output> for AppError {
-    fn from(value: Output) -> Self {
-        let out = String::from_utf8_lossy(&value.stdout);
-        let err = String::from_utf8_lossy(&value.stderr);
-
-        return AppError::new_with_exit_code(
-            anyhow!("stderr: {}\nstdout: {}", err, out),
-            value.status.code().unwrap_or(1),
-        );
+pub fn output_to_result(output: Output) -> AppResult<Output> {
+    let status = output.status;
+    if status.success() {
+        Ok(output)
+    } else {
+        let out = String::from_utf8_lossy(&output.stdout);
+        let err = String::from_utf8_lossy(&output.stderr);
+        Err(anyhow!(
+            "Exit status: {}.\nstderr: {}\nstdout: {}",
+            status,
+            err,
+            out
+        ))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,14 @@ use log::{debug, error, info, warn};
 use prelude::*;
 use std::{collections::HashSet, fmt, fs, str::FromStr};
 
-mod app_error;
+pub mod app_error;
 
-mod prelude {
-    pub use anyhow::{anyhow, bail};
-    pub type AppError = crate::app_error::AppError;
-    pub type AppResult<T = ()> = Result<T, AppError>;
+pub mod prelude {
+    pub use crate::app_error;
+    pub use anyhow::{anyhow, bail, Context};
     pub type AnyError = anyhow::Error;
+    pub type AppError = AnyError;
+    pub type AppResult<T = ()> = Result<T, AnyError>;
 }
 
 use crate::{
@@ -175,7 +176,7 @@ impl Default for Entity {
 }
 
 /// Main function that handles user management
-pub fn run_mgmt(args: cli::GeneralArgs, config: MgmtConfig) {
+pub fn run_mgmt(args: cli::GeneralArgs, config: MgmtConfig) -> AppResult {
     let is_slurm_only = args.slurm_only;
     let is_ldap_only = args.ldap_only;
     let directories_only = args.dirs_only;
@@ -188,7 +189,7 @@ pub fn run_mgmt(args: cli::GeneralArgs, config: MgmtConfig) {
             &is_ldap_only,
             &directories_only,
             &config,
-        ),
+        )?,
         Commands::Modify { data } => modify_user(data.clone(), config, is_slurm_only, is_ldap_only),
         Commands::Delete { user } => delete_user(
             &user,
@@ -202,6 +203,8 @@ pub fn run_mgmt(args: cli::GeneralArgs, config: MgmtConfig) {
             ldap_users,
         } => list_users(&config, &slurm_users, &ldap_users),
     }
+
+    Ok(())
 }
 
 /// Check if sequence `qos` contains only valid QOS values.
@@ -269,7 +272,7 @@ fn add_user(
     is_ldap_only: &bool,
     directories_only: &bool,
     config: &MgmtConfig,
-) {
+) -> AppResult {
     debug!("Start add_user");
 
     let sacctmgr_path = config.sacctmgr_path.clone();
@@ -284,9 +287,7 @@ fn add_user(
             slurm::remote::add_slurm_user(&entity, config, &ssh_credentials);
         } else {
             // Call sacctmgr binary directly via subprocess
-
-            let after = slurm::local::add_slurm_user(&entity, &sacctmgr_path);
-            exit_if_app_error(&after);
+            slurm::local::add_slurm_user(&entity, &sacctmgr_path)?;
         }
     }
 
@@ -305,6 +306,8 @@ fn add_user(
     }
 
     debug!("Finished add_user");
+
+    Ok(())
 }
 
 fn delete_user(
@@ -397,17 +400,6 @@ fn list_users(config: &MgmtConfig, slurm: &bool, ldap: &bool) {
 
     if *ldap {
         ldap::ldap::list_ldap_users(config);
-    }
-}
-
-/// If given parmater `maybe_error` is an error
-/// then the application prints out error information to the user and
-/// exits with error code of provided error.
-fn exit_if_app_error<T>(maybe_error: &AppResult<T>) {
-    if let Err(error) = maybe_error {
-        error!("{:?}", error);
-
-        std::process::exit(error.exit_code());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,32 +3,55 @@ use env_logger::Env;
 use log::error;
 use std::fs;
 use std::path::Path;
+use std::process::ExitCode;
 use usermgmt::cli::GeneralArgs;
 use usermgmt::config::config::MgmtConfig;
+use usermgmt::prelude::*;
 use usermgmt::run_mgmt;
 
-fn main() {
+/// Name of the file in which all values for configuration of this app are located
+/// besides the CLI arguments.
+const NAME_CONFIG_FILE: &str = "conf.toml";
+
+fn main() -> ExitCode {
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
         .format_timestamp(None)
         .init();
 
     let config_file_basedir = if cfg!(target_os = "linux") && cfg!(not(debug_assertions)) {
-        "/etc/usermgmt".to_owned()
+        Path::new("/etc/usermgmt")
     } else {
-        ".".to_owned()
+        Path::new(".")
     };
 
-    fs::create_dir_all(&config_file_basedir).unwrap();
-    let path_string = config_file_basedir + "/conf.toml";
-    let path = Path::new(&path_string);
+    if let Err(error) = execute_command(config_file_basedir) {
+        error!("Error: {:?}", error);
+        return ExitCode::FAILURE;
+    };
+
+    ExitCode::SUCCESS
+}
+
+/// Executes action adding/deleting/changing user with arguments from CLI and values from
+/// configuration file
+fn execute_command(config_file_basedir: &Path) -> AppResult {
+    let config = load_config(config_file_basedir).context("Configuration error")?;
+    let args = GeneralArgs::parse();
+    run_mgmt(args, config)
+}
+
+/// Tries to load  config.toml for application.
+///
+/// # Error
+///
+/// - Can not ensure if folder exits where conf.toml file exits
+/// - Can not read or create a configuration file
+fn load_config(config_file_basedir: &Path) -> AppResult<MgmtConfig> {
+    fs::create_dir_all(config_file_basedir)
+        .with_context(|| format!("Could not create folder for {:?}", config_file_basedir))?;
+    let path = config_file_basedir.join(NAME_CONFIG_FILE);
 
     // Load (or create if nonexistent) configuration file conf.toml
-    let cfg: Result<MgmtConfig, confy::ConfyError> = confy::load_path(path);
-    match cfg {
-        Ok(config) => {
-            let args = GeneralArgs::parse();
-            run_mgmt(args, config);
-        }
-        Err(e) => error!("Configuration error: {:?}", e),
-    }
+    confy::load_path(&path)
+        .with_context(|| format!("Error in loading or creating config file at {:?}", path))
 }


### PR DESCRIPTION
Previously used exit prevents stack unwinding

Removed not needed extra wrapper error type.
Using anyhow error directly provides the following advantages:

- Access to context and with_context to annotate failure more easily
- "thiserror" as dependency not needed anymore