### PR TITLE
Rework of prompting from TTY with validation for emptiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Added option to use different user prefix and org unit binding for readonly LDAP user.
-- Made username and password optional for readonly user to allow for prompting these credentials.
-
-### Changed
-
+- Username and passwords which are empty or only white spaces and have default value are invalid 
 - Output of for LDAP user via the sub command list is now presented in a nicer ASCII table format
 - CLI argument for slurm, ldap and directory management can be toggled via cli and conf.toml individually
   CLI Option for a system is only available if a sub command supports it.
@@ -23,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added option to use different user prefix and org unit binding for readonly LDAP user.
+- Made username and password optional for readonly user to allow for prompting these credentials.
 - Used base dc, dn for user manipulation and dn for user bind are now logged.
 - Port for ssh connection can now specified via configuration file
 

--- a/src/ldap/ldap_config.rs
+++ b/src/ldap/ldap_config.rs
@@ -1,4 +1,4 @@
-use crate::MgmtConfig;
+use crate::{prelude::AppResult, MgmtConfig};
 
 use super::ldap_paths::LdapPaths;
 #[derive(Debug, Default)]
@@ -11,7 +11,11 @@ pub struct LDAPConfig {
 }
 
 impl LDAPConfig {
-    pub fn new(config: &MgmtConfig, username: &Option<String>, password: &Option<String>) -> Self {
+    pub fn new(
+        config: &MgmtConfig,
+        username: &Option<String>,
+        password: &Option<String>,
+    ) -> AppResult<Self> {
         let (bind_prefix, ldap_server, dc, org_unit, bind_org_unit) = (
             &config.ldap_bind_prefix,
             &config.ldap_server,
@@ -24,7 +28,7 @@ impl LDAPConfig {
             username.as_deref(),
             password.as_deref(),
             super::ask_credentials_in_tty,
-        );
+        )?;
 
         let ldap_paths = LdapPaths::new(
             dc.clone(),
@@ -34,11 +38,11 @@ impl LDAPConfig {
             ldap_user,
         );
 
-        Self {
+        Ok(Self {
             ldap_server: ldap_server.to_string(),
             ldap_pass,
             ldap_paths,
-        }
+        })
     }
 
     pub fn bind(&self) -> &str {

--- a/src/ldap/testing.rs
+++ b/src/ldap/testing.rs
@@ -12,7 +12,8 @@ fn should_give_correct_ldap_paths() {
         let given = MgmtConfig {
             ..MgmtConfig::default()
         };
-        let actual = LDAPConfig::new(&given, &Some("xxx".to_owned()), &Some("xxxx".to_owned()));
+        let actual =
+            LDAPConfig::new(&given, &Some("xxx".to_owned()), &Some("xxxx".to_owned())).unwrap();
         assert_case(
             ExpectedLdapPaths {
                 ldap_base: "".to_owned(),
@@ -31,7 +32,8 @@ fn should_give_correct_ldap_paths() {
             ..MgmtConfig::default()
         };
 
-        let actual = LDAPConfig::new(&given, &Some("alice".to_owned()), &Some("xxxx".to_owned()));
+        let actual =
+            LDAPConfig::new(&given, &Some("alice".to_owned()), &Some("xxxx".to_owned())).unwrap();
 
         assert_case(
             ExpectedLdapPaths {
@@ -46,7 +48,8 @@ fn should_give_correct_ldap_paths() {
             ldap_domain_components: Some("dc=example,dc=com".to_owned()),
             ..MgmtConfig::default()
         };
-        let actual = LDAPConfig::new(&given, &Some("alice".to_owned()), &Some("xxxx".to_owned()));
+        let actual =
+            LDAPConfig::new(&given, &Some("alice".to_owned()), &Some("xxxx".to_owned())).unwrap();
         assert_case(
             ExpectedLdapPaths {
                 ldap_base: "dc=example,dc=com".to_owned(),
@@ -61,7 +64,8 @@ fn should_give_correct_ldap_paths() {
             ldap_org_unit: Some("aaa=department,bbb=level".to_owned()),
             ..MgmtConfig::default()
         };
-        let actual = LDAPConfig::new(&given, &Some("alice".to_owned()), &Some("xxxx".to_owned()));
+        let actual =
+            LDAPConfig::new(&given, &Some("alice".to_owned()), &Some("xxxx".to_owned())).unwrap();
         assert_case(
             ExpectedLdapPaths {
                 ldap_base: "aaa=department,bbb=level,dc=example,dc=com".to_owned(),

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::AppResult, util::io_util};
+use crate::prelude::AppResult;
 use log::debug;
 mod ssh_connection;
 mod ssh_credential;
@@ -7,18 +7,6 @@ pub use ssh_connection::SshSession;
 
 pub use ssh_credential::SshCredential;
 
-/// Asks user over the terminal for a username and password which are meant to be used for the
-/// authentication in a ssh connection
-fn ask_credentials_for_ssh(default_user: &str) -> (String, String) {
-    println!("Enter your SSH username (defaults to {}):", default_user);
-
-    let mut username = io_util::user_input();
-    if username.is_empty() {
-        username = default_user.to_string();
-    }
-    let password = rpassword::prompt_password("Enter your SSH password: ").unwrap();
-    (username, password)
-}
 /// Executes given command `cmd` on remote machine over ssh
 ///
 /// TODO: move checking if for exit code inside here and return result instead of error code

--- a/src/ssh/ssh_connection.rs
+++ b/src/ssh/ssh_connection.rs
@@ -62,7 +62,7 @@ impl<'a, 'b> SshSession<'a, 'b> {
             sess.handshake()
                 .context("Could not perform ssh handshake")?;
 
-            let (username, password) = (self.credentials.username(), self.credentials.password());
+            let (username, password) = (self.credentials.username()?, self.credentials.password()?);
             sess.userauth_password(username, password)
                 .context("Authentication has failed with provided username/password.")?;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,122 +1,109 @@
 mod result_accumalator;
 pub use result_accumalator::ResultAccumalator;
+pub mod user_input;
 
-pub mod io_util {
-    use crate::prelude::AppResult;
-    use crate::Group;
-    use anyhow::bail;
-    use log::debug;
-    use std::collections::HashSet;
-    use std::io;
+use crate::prelude::AppResult;
+use crate::Group;
+use anyhow::bail;
+use log::debug;
+use std::collections::HashSet;
 
-    const STUDENT_UID: u32 = 10_000;
-    const STAFF_UID: u32 = 1_000;
+const STUDENT_UID: u32 = 10_000;
+const STAFF_UID: u32 = 1_000;
 
-    pub fn user_input() -> String {
-        let mut input = String::new();
+pub fn hashset_from_vec_str<R>(data: &'_ [R]) -> HashSet<&'_ str>
+where
+    R: AsRef<str>,
+{
+    data.iter().map(|s| s.as_ref()).collect::<HashSet<&str>>()
+}
 
-        io::stdin()
-            .read_line(&mut input)
-            .expect("Failed to read user input");
+/// Returns uid which can be used for a new user.
+///
+/// # Errors
+/// - if next uid would cause overflow because of its size
+/// - if next staff uid would be so big that it becomes a student id
+///  
+pub fn get_new_uid(uids: &[u32], group: crate::Group) -> AppResult<u32> {
+    // students start at 10000, staff at 1000
+    let result = if group == Group::Student {
+        uids.iter()
+            .filter(|&&i| i >= STUDENT_UID)
+            .collect::<Vec<_>>()
+    } else {
+        uids.iter()
+            .filter(|i| (STAFF_UID..STUDENT_UID).contains(i))
+            .collect::<Vec<_>>()
+    };
 
-        input = input.trim().to_string();
-        input
-    }
+    let max_value = result.iter().max();
+    match max_value {
+        Some(&&max) => {
+            debug!("Next available uid is: {}", max + 1);
 
-    pub fn hashset_from_vec_str<R>(data: &'_ [R]) -> HashSet<&'_ str>
-    where
-        R: AsRef<str>,
-    {
-        data.iter().map(|s| s.as_ref()).collect::<HashSet<&str>>()
-    }
+            let (next_uid, has_overflow) = max.overflowing_add(1);
 
-    /// Returns uid which can be used for a new user.
-    ///
-    /// # Errors
-    /// - if next uid would cause overflow because of its size
-    /// - if next staff uid would be so big that it becomes a student id
-    ///  
-    pub fn get_new_uid(uids: &[u32], group: crate::Group) -> AppResult<u32> {
-        // students start at 10000, staff at 1000
-        let result = if group == Group::Student {
-            uids.iter()
-                .filter(|&&i| i >= STUDENT_UID)
-                .collect::<Vec<_>>()
-        } else {
-            uids.iter()
-                .filter(|i| (STAFF_UID..STUDENT_UID).contains(i))
-                .collect::<Vec<_>>()
-        };
-
-        let max_value = result.iter().max();
-        match max_value {
-            Some(&&max) => {
-                debug!("Next available uid is: {}", max + 1);
-
-                let (next_uid, has_overflow) = max.overflowing_add(1);
-
-                if has_overflow {
-                    bail!("Next uid would cause an overflow for an unsigned integer 32".to_string(),)
-                }
-
-                if group == Group::Staff && next_uid >= STUDENT_UID {
-                    bail!("Next uid for staff goes into uid range of students !. Students range starts at {}", STUDENT_UID);
-                }
-
-                Ok(next_uid)
+            if has_overflow {
+                bail!("Next uid would cause an overflow for an unsigned integer 32".to_string(),)
             }
-            None => {
-                if group == Group::Student {
-                    Ok(STUDENT_UID + 1)
-                } else {
-                    Ok(STAFF_UID + 1)
-                }
+
+            if group == Group::Staff && next_uid >= STUDENT_UID {
+                bail!("Next uid for staff goes into uid range of students !. Students range starts at {}", STUDENT_UID);
+            }
+
+            Ok(next_uid)
+        }
+        None => {
+            if group == Group::Student {
+                Ok(STUDENT_UID + 1)
+            } else {
+                Ok(STAFF_UID + 1)
             }
         }
     }
+}
 
-    #[cfg(test)]
-    mod testing {
-        use maplit::hashset;
+#[cfg(test)]
+mod testing {
+    use maplit::hashset;
 
-        use super::*;
-        #[test]
-        fn should_return_next_uid() {
-            // With existing staff and students
-            let example_uids = vec![10001, 10002, 10005, 10003, 1001];
-            assert_return_next_uid(&vec![], Group::Staff, 1001);
-            assert_return_next_uid(&vec![], Group::Student, 10001);
-            // Only with existing staff
-            assert_return_next_uid(&vec![1001, 1002], Group::Student, 10001);
-            // Only with existing students
-            assert_return_next_uid(&vec![10001, 10002], Group::Staff, 1001);
-            assert_return_next_uid(&example_uids, Group::Student, 10006);
-            assert_return_next_uid(&example_uids, Group::Staff, 1002);
-        }
+    use super::*;
+    #[test]
+    fn should_return_next_uid() {
+        // With existing staff and students
+        let example_uids = vec![10001, 10002, 10005, 10003, 1001];
+        assert_return_next_uid(&vec![], Group::Staff, 1001);
+        assert_return_next_uid(&vec![], Group::Student, 10001);
+        // Only with existing staff
+        assert_return_next_uid(&vec![1001, 1002], Group::Student, 10001);
+        // Only with existing students
+        assert_return_next_uid(&vec![10001, 10002], Group::Staff, 1001);
+        assert_return_next_uid(&example_uids, Group::Student, 10006);
+        assert_return_next_uid(&example_uids, Group::Staff, 1002);
+    }
 
-        #[test]
-        fn should_return_error_for_overflow() {
-            let actual = get_new_uid(&vec![u32::MAX], Group::Student);
-            assert!(actual.is_err());
-        }
-        #[test]
-        fn should_return_error_for_staff_into_student() {
-            let actual = get_new_uid(&vec![STUDENT_UID - 1], Group::Staff);
-            assert!(actual.is_err());
-        }
+    #[test]
+    fn should_return_error_for_overflow() {
+        let actual = get_new_uid(&vec![u32::MAX], Group::Student);
+        assert!(actual.is_err());
+    }
+    #[test]
+    fn should_return_error_for_staff_into_student() {
+        let actual = get_new_uid(&vec![STUDENT_UID - 1], Group::Staff);
+        assert!(actual.is_err());
+    }
 
-        #[test]
-        fn should_hashset_from_vec_str() {
-            let given = vec!["one", "one", "two", "three"];
-            let actual = hashset_from_vec_str(&given);
-            let expected = hashset! {"one", "two", "three"};
-            assert_eq!(expected, actual);
-        }
+    #[test]
+    fn should_hashset_from_vec_str() {
+        let given = vec!["one", "one", "two", "three"];
+        let actual = hashset_from_vec_str(&given);
+        let expected = hashset! {"one", "two", "three"};
+        assert_eq!(expected, actual);
+    }
 
-        fn assert_return_next_uid(uids: &[u32], group: crate::Group, expected_uid: u32) {
-            let actual = get_new_uid(uids, group);
-            let actual_value = actual.expect("Should not be an error for valid input");
-            assert_eq!(actual_value, expected_uid);
-        }
+    fn assert_return_next_uid(uids: &[u32], group: crate::Group, expected_uid: u32) {
+        let actual = get_new_uid(uids, group);
+        let actual_value = actual.expect("Should not be an error for valid input");
+        assert_eq!(actual_value, expected_uid);
     }
 }

--- a/src/util/user_input.rs
+++ b/src/util/user_input.rs
@@ -1,0 +1,177 @@
+//! Functions to acquire information from the user by asking for it in the terminal.
+
+use std::io;
+
+use anyhow::{anyhow, Context};
+
+use crate::prelude::AppResult;
+
+fn ask_for_line_from_user(
+    on_input: impl Fn() -> AppResult<Option<String>>,
+    on_output: impl Fn(String),
+    prompt: &str,
+    placeholder: Option<&str>,
+) -> AppResult<String> {
+    let final_placeholer_prompt = match placeholder {
+        Some(value) => format!(" (defaults to ({}))", value),
+        None => String::new(),
+    };
+
+    let final_prompt = format!("{}{}", prompt, final_placeholer_prompt);
+    on_output(final_prompt);
+    let received_input = on_input()?;
+
+    match received_input {
+        Some(input) => Ok(input),
+        None => match placeholder {
+            Some(to_use_instead) => Ok(to_use_instead.to_owned()),
+            None => Err(anyhow!("No entered input for the field".to_string())),
+        },
+    }
+}
+
+/// Ask the user for an line until new line is given over the terminal.
+/// A prompt is shown to the user in the terminal.
+/// If no input is given by the user, the placeholder is returned
+///
+/// # Returns
+///
+/// - None if input is empty or only white spaces
+/// - Some if input has at least on char which is not white space. Inner value is trimmed or the
+/// placeholder if no input was provided.
+///
+/// # Errors
+///
+/// - if reading from the terminal does not work. For example terminal is not accessible.
+pub fn ask_for_line_from_user_over_term(
+    prompt: &str,
+    placeholder: Option<&str>,
+) -> AppResult<String> {
+    ask_for_line_from_user(
+        line_input_from_user,
+        |input| println!("{}", input),
+        prompt,
+        placeholder,
+    )
+}
+
+/// Ask the user for an line until new line is given over the terminal.
+///
+/// # Returns
+///
+/// - None if input is empty or only white spaces
+/// - Some if input has at least on char which is not white space. Inner value is trimmed.
+///
+/// # Errors
+///
+/// - if reading from the terminal does not work. For example terminal is not accessible.
+pub fn line_input_from_user() -> AppResult<Option<String>> {
+    let mut input = String::new();
+
+    io::stdin()
+        .read_line(&mut input)
+        .context("Failed to read user input")?;
+
+    Ok(trim_input(&input))
+}
+
+/// Ask the user for a password until new line is given  over the terminal.
+///
+/// # Returns
+///
+/// - None if input is empty or only white spaces
+/// - Some if input has at least on char which is not white space. Inner value is trimmed.
+///
+/// # Errors
+///
+/// - if reading from the terminal does not work. For example terminal is not accessible.
+pub fn ask_for_password(prompt: &str) -> AppResult<Option<String>> {
+    let password =
+        rpassword::prompt_password(prompt).context("Could not retrieve password from prompt !")?;
+    Ok(trim_input(&password))
+}
+
+fn trim_input(input: &str) -> Option<String> {
+    let input = input.trim().to_string();
+
+    if input.is_empty() {
+        None
+    } else {
+        Some(input)
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use super::*;
+
+    #[test]
+    fn take_placeholder_over_empty_input() {
+        let placeholder = String::from("place holder ...");
+        let prompt = "Some prompt";
+
+        let actual = ask_for_line_from_user(
+            || Ok(None),
+            |output| {
+                let expected = format!("{} (defaults to ({}))", prompt, placeholder);
+                assert_eq!(expected, output);
+            },
+            "Some prompt",
+            Some(&placeholder),
+        );
+
+        assert_eq!(placeholder, actual.unwrap());
+    }
+    #[test]
+    fn take_input_over_placeholder() {
+        let placeholder = String::from("place holder ...");
+        let prompt = "Some prompt";
+
+        let input = "Input !".to_owned();
+        let actual = ask_for_line_from_user(
+            || Ok(Some(input.clone())),
+            |output| {
+                let expected = format!("{} (defaults to ({}))", prompt, placeholder);
+                assert_eq!(expected, output);
+            },
+            "Some prompt",
+            Some(&placeholder),
+        );
+
+        assert_eq!(input, actual.unwrap());
+    }
+    #[test]
+    fn prompt_without_default_and_input_was_given() {
+        let prompt = "Some prompt";
+
+        let input = "Input !".to_owned();
+        let actual = ask_for_line_from_user(
+            || Ok(Some(input.clone())),
+            |output| {
+                let expected = format!("{}", prompt);
+                assert_eq!(expected, output);
+            },
+            "Some prompt",
+            None,
+        );
+
+        assert_eq!(input, actual.unwrap());
+    }
+
+    #[test]
+    fn no_input_given() {
+        let prompt = "Some prompt";
+
+        let input = None;
+        let actual = ask_for_line_from_user(
+            || Ok(input.clone()),
+            |output| {
+                let expected = format!("{}", prompt);
+                assert_eq!(expected, output);
+            },
+            "Some prompt",
+            None,
+        );
+        assert!(actual.is_err());
+    }
+}


### PR DESCRIPTION
# Change

Providing an empty or white space for username or password for ssh or ldap login will yield an error if no placeholder is available.

# Issues

Relates to issue https://github.com/th-nuernberg/usermgmt/issues/52 .