### PR TITLE
Feat: several folders are checked for configuration file to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Configuration file is not created automatically anymore
 - Username and passwords which are empty or only white spaces and have default value are invalid 
 - Output of for LDAP user via the sub command list is now presented in a nicer ASCII table format
 - CLI argument for slurm, ldap and directory management can be toggled via cli and conf.toml individually
@@ -19,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Configuration file can be located in several places. 
+  It always try user specific configuration locations, then system configuration places and the CWD as the last resort.
+- Default configuration can be generated via new subcommand "generate-config".
 - Option to try authentication via ssh agent before simple password authentication.
 - Added option to use different user prefix and org unit binding for readonly LDAP user.
 - Made username and password optional for readonly user to allow for prompting these credentials.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "2913470204e9e8498a0f31f17f90a0de801ae92c8c5ac18c49af4819e6786697"
 dependencies = [
  "directories",
  "serde",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -272,7 +272,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
 dependencies = [
  "cfg-if 0.1.10",
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -294,6 +303,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -505,6 +526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +569,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "insta"
 version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +587,7 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "serde",
  "similar",
  "yaml-rust",
 ]
@@ -822,6 +860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1130,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1349,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1447,7 @@ dependencies = [
  "anyhow",
  "clap",
  "confy",
+ "dirs",
  "env_logger",
  "getset",
  "insta",
@@ -1372,6 +1460,7 @@ dependencies = [
  "serde",
  "ssh2",
  "tempfile",
+ "toml 0.7.4",
 ]
 
 [[package]]
@@ -1575,6 +1664,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ once_cell = "1.17.1"
 anyhow = { version = "1.0.70", features = ["backtrace"] }
 prettytable = "0.10.0"
 getset = "0.1.2"
+dirs = "5.0.1"
+toml = "0.7.4"
 
 [dev-dependencies]
-insta = "1.29.0"
+insta = { version = "1.29.0", features = ["yaml"] }
 
 [package.metadata.deb]
 maintainer = "Dominik Wagner <dominik.wagner@th-nuernberg.de>"

--- a/README.md
+++ b/README.md
@@ -121,9 +121,38 @@ cp conf.toml /etc/usermgmt
 
 ## Configuration
 
-A basic configuration file (`conf.toml`) will be created upon first start of the application. 
-In development mode, the file can be found at `./conf.toml`, in release mode the file will be located at `/etc/usermgmt/conf.toml`. 
-You can savely modify the file after its initial creation. 
+### Location of configuration file
+
+A basic configuration file (`conf.toml`) is loaded during runtime. 
+This file determines a large portion of the behaviour of the program. 
+The programs tries load the configuration file from several places.
+The first found configuration file is loaded.
+The search is conducted in the following order: 
+
+- Under user specific configuration places according to the OS.
+  - Which folder on which OS is used, can be looked up [here](https://docs.rs/dirs/latest/dirs/fn.config_dir.html)
+  - In Addition under Linux: "~/.usermgmt" 
+- Under the system wide paths in respect to the OS
+  - Under Linux: "/usr/usermgmt"
+- The CWD as the last resort 
+
+The program does not create the configuration file and the locations listed above, automatically !
+You do not need to create the configuration from scratch though.
+By using the command generate-config like this 
+
+```sh
+usermgmt generate-config
+```
+
+You can acquire a default configuration. This ouput goes to the stdout of the terminal by default. 
+You can create a local configuration file via piping.
+This example creates a local default configuration file at '/home/foo/conf.toml' via piping
+
+```sh
+usermgmt generate-config > /home/foo/conf.toml
+```
+
+### Structure and content of configuration file
 
 The `conf.toml` file looks as follows:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,9 @@ pub enum Commands {
         #[clap(long, verbatim_doc_comment)]
         simple_output_for_ldap: Option<bool>,
     },
+    /// Outputs a default configuration, aka conf.toml, to stdout.
+    /// Pipe it to a path for a file to generate a permanent configuration somewhere.
+    GenerateConfig,
 }
 
 /// Defines options that can be modified

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+mod path_sources;
+pub use path_sources::get_path_to_conf;
 /// Definition of configuration options
 use serde::{Deserialize, Serialize};
 

--- a/src/config/path_sources.rs
+++ b/src/config/path_sources.rs
@@ -1,0 +1,255 @@
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
+use log::{debug, info};
+use once_cell::sync::Lazy;
+
+use crate::prelude::AppResult;
+/// Name of the file in which all values for configuration of this app are located
+/// besides the CLI arguments.
+const NAME_CONFIG_FILE: &str = "conf.toml";
+
+static HOME_LOCATIONS: Lazy<Vec<PathBuf>> = Lazy::new(|| {
+    let os_config = dirs::config_dir();
+    let mut paths: Vec<PathBuf> = Vec::with_capacity(2);
+    if let Some(config) = os_config {
+        paths.push(config);
+    }
+    if cfg!(unix) {
+        paths.push(PathBuf::from("~/.usermgmt"));
+    }
+    paths
+});
+
+static SYSTEM_LOCATIONS: Lazy<Vec<PathBuf>> = Lazy::new(|| {
+    let mut paths = Vec::with_capacity(1);
+    if cfg!(unix) {
+        paths.push(PathBuf::from("/usr/usermgmt"))
+    }
+    paths
+});
+
+/// Gets the first absolute path to an existing configuration file with named `NAME_CONFIG_FILE`.
+///
+/// At first It searches all places for a specific user. These paths are `HOME_LOCATIONS`.
+/// If nothing is found there, all places for system settings are searched aka `SYSTEM_LOCATIONS`
+/// If nothing is found there too, it searches CWD for the configuration file.
+///
+/// # Errors
+///
+/// - If no configuration file could be found anywhere.
+/// - If CWD can not be determined after the configuration file could not be found under the home and
+/// system paths.
+///
+pub fn get_path_to_conf() -> AppResult<PathBuf> {
+    get_path_to_conf_with_dep(
+        try_resolve_paths_with_home,
+        |to_check| may_return_path_to_conf(io_try_exists, to_check),
+        try_cwd_as_last_resort,
+        &SYSTEM_LOCATIONS,
+    )
+}
+
+fn get_path_to_conf_with_dep(
+    on_resolve_paths_with_home: impl Fn(Option<PathBuf>, &[PathBuf]) -> Vec<PathBuf>,
+    on_may_return_path_to_conf: impl Fn(&Path) -> Option<PathBuf>,
+    on_try_cwd_as_last_resort: impl Fn() -> AppResult<PathBuf>,
+    system_paths: &[PathBuf],
+) -> AppResult<PathBuf> {
+    let home_dirs: Vec<PathBuf> = on_resolve_paths_with_home(dirs::home_dir(), &HOME_LOCATIONS);
+
+    let first_find: Option<PathBuf> = home_dirs
+        .into_iter()
+        .chain(
+            system_paths
+                .iter()
+                .map(|to_resolve| PathBuf::from(&to_resolve)),
+        )
+        .flat_map(|to_check| on_may_return_path_to_conf(&to_check))
+        .next();
+
+    match first_find {
+        Some(first_match) => Ok(first_match),
+        None => on_try_cwd_as_last_resort(),
+    }
+}
+
+fn try_resolve_paths_with_home(home_folder: Option<PathBuf>, folders: &[PathBuf]) -> Vec<PathBuf> {
+    match home_folder {
+        Some(dir) => {
+            let resolve_dir = dir;
+            folders
+                .iter()
+                .map(|to_resolve| match to_resolve.strip_prefix("~") {
+                    Ok(stripped) => PathBuf::from(&resolve_dir).join(stripped),
+                    Err(error) => {
+                        debug!(
+                            "Striping prefix did not occured for {:?}. Details: {}",
+                            to_resolve, error
+                        );
+                        to_resolve.clone()
+                    }
+                })
+                .collect()
+        }
+        None => {
+            debug!(
+                "Could not get any home directory loaction skipping checking for locations {:?}",
+                HOME_LOCATIONS
+            );
+
+            Vec::new()
+        }
+    }
+}
+
+fn try_cwd_as_last_resort() -> AppResult<PathBuf> {
+    debug!("No configuration file found in the previous paths. Trying to get configuration file in cwd.");
+    let cwd = std::env::current_dir().context(
+                "No folder found, cwd directory as last alternative could not be retrieved.\n No conf.toml could be found",
+            )?;
+    let last_resort = may_return_path_to_conf(io_try_exists, &cwd).ok_or(anyhow::anyhow!(
+        "path at {:?} as last alternative does also not exits.\n No conf.toml could be found",
+        cwd
+    ))?;
+    info!(
+        "Using cwd path {:?} for configuration file as last resort.",
+        last_resort
+    );
+
+    Ok(last_resort)
+}
+
+fn may_return_path_to_conf(
+    try_exists: impl Fn(&Path) -> io::Result<bool>,
+    path: &Path,
+) -> Option<PathBuf> {
+    let to_check = path.join(NAME_CONFIG_FILE);
+    match try_exists(&to_check) {
+        Ok(exits) => {
+            if exits {
+                Some(to_check)
+            } else {
+                debug!("Path at {:?} does not exits", to_check);
+                None
+            }
+        }
+        Err(error) => {
+            debug!(
+                "Could not check existance for path at {:?}\n. Error: {}",
+                to_check, error
+            );
+            None
+        }
+    }
+}
+
+fn io_try_exists(path: &Path) -> io::Result<bool> {
+    path.try_exists()
+}
+
+#[cfg(test)]
+mod testing {
+    use std::io::ErrorKind;
+
+    use anyhow::anyhow;
+
+    use super::*;
+
+    #[test]
+    fn return_empty_if_no_home_folder() {
+        let actual = try_resolve_paths_with_home(None, &[]);
+        assert!(actual.is_empty());
+    }
+
+    #[test]
+    fn return_resolve_with_home_folder() {
+        let actual = try_resolve_paths_with_home(
+            Some(PathBuf::from("/home")),
+            &["~/foo", "~/bar", "~/.tool", "~", "~/hello_~"]
+                .iter()
+                .map(PathBuf::from)
+                .collect::<Vec<PathBuf>>(),
+        );
+        insta::assert_yaml_snapshot!(actual);
+    }
+
+    #[test]
+    fn return_none_if_io_error_for_path_check() {
+        let actual = may_return_path_to_conf(
+            |_| Err(io::Error::new(ErrorKind::Other, "Some error")),
+            &PathBuf::from("/"),
+        );
+
+        assert!(actual.is_none());
+    }
+    #[test]
+    fn return_none_if_path_does_not_exits() {
+        let actual = may_return_path_to_conf(|_| Ok(false), &PathBuf::from("/"));
+
+        assert!(actual.is_none());
+    }
+    #[test]
+    fn return_some_if_path_exits() {
+        let expected = Some(PathBuf::from("/home").join(NAME_CONFIG_FILE));
+        let actual = may_return_path_to_conf(|_| Ok(true), &PathBuf::from("/home"));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn error_for_no_path_found() {
+        let actual =
+            get_path_to_conf_with_dep(|_, _| Vec::new(), |_| None, || Err(anyhow!("")), &[]);
+        assert!(actual.is_err());
+    }
+    #[test]
+    fn cwd_if_home_and_others_are_none() {
+        let expected = PathBuf::from("/home");
+        let actual = get_path_to_conf_with_dep(
+            |_, _| Vec::new(),
+            |_| None,
+            || Ok(PathBuf::from("/home")),
+            &Vec::new(),
+        );
+        assert_eq!(expected, actual.unwrap());
+    }
+    #[test]
+    fn others_before_cwd() {
+        let expected = PathBuf::from("/usr/home");
+        let actual = get_path_to_conf_with_dep(
+            |_, _| Vec::new(),
+            |to_match| {
+                if to_match == &expected {
+                    Some(to_match.to_owned())
+                } else {
+                    None
+                }
+            },
+            || Ok(PathBuf::from("/home")),
+            &["foo".into(), "/usr/home".into(), "bar".into()],
+        );
+        assert_eq!(expected, actual.unwrap());
+    }
+
+    #[test]
+    fn home_before_others_before_cwd() {
+        let expected = PathBuf::from("/home/bar");
+        let actual = get_path_to_conf_with_dep(
+            |_, _| vec![expected.clone()],
+            |to_match| {
+                if to_match == &expected {
+                    Some(to_match.to_owned())
+                } else {
+                    None
+                }
+            },
+            || Ok(PathBuf::from("/home")),
+            &["foo".into(), "/usr/home".into(), "bar".into()],
+        );
+        assert_eq!(expected, actual.unwrap());
+    }
+}

--- a/src/config/snapshots/usermgmt__config__path_sources__testing__return_resolve_with_home_folder.snap
+++ b/src/config/snapshots/usermgmt__config__path_sources__testing__return_resolve_with_home_folder.snap
@@ -1,0 +1,10 @@
+---
+source: src/config/path_sources.rs
+expression: actual
+---
+- /home/foo
+- /home/bar
+- /home/.tool
+- /home/
+- /home/hello_~
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,17 @@
 use clap::Parser;
 use env_logger::Env;
 use log::error;
-use std::fs;
-use std::path::Path;
 use std::process::ExitCode;
 use usermgmt::cli::GeneralArgs;
-use usermgmt::config::MgmtConfig;
 use usermgmt::prelude::*;
 use usermgmt::run_mgmt;
-
-/// Name of the file in which all values for configuration of this app are located
-/// besides the CLI arguments.
-const NAME_CONFIG_FILE: &str = "conf.toml";
 
 fn main() -> ExitCode {
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
         .format_timestamp(None)
         .init();
 
-    let config_file_basedir = if cfg!(target_os = "linux") && cfg!(not(debug_assertions)) {
-        Path::new("/etc/usermgmt")
-    } else {
-        Path::new(".")
-    };
-
-    if let Err(error) = execute_command(config_file_basedir) {
+    if let Err(error) = execute_command() {
         error!("Error: {:?}", error);
         return ExitCode::FAILURE;
     };
@@ -34,24 +21,7 @@ fn main() -> ExitCode {
 
 /// Executes action adding/deleting/changing user with arguments from CLI and values from
 /// configuration file
-fn execute_command(config_file_basedir: &Path) -> AppResult {
-    let config = load_config(config_file_basedir).context("Configuration error")?;
+fn execute_command() -> AppResult {
     let args = GeneralArgs::parse();
-    run_mgmt(args, config)
-}
-
-/// Tries to load  config.toml for application.
-///
-/// # Error
-///
-/// - Can not ensure if folder exits where conf.toml file exits
-/// - Can not read or create a configuration file
-fn load_config(config_file_basedir: &Path) -> AppResult<MgmtConfig> {
-    fs::create_dir_all(config_file_basedir)
-        .with_context(|| format!("Could not create folder for {:?}", config_file_basedir))?;
-    let path = config_file_basedir.join(NAME_CONFIG_FILE);
-
-    // Load (or create if nonexistent) configuration file conf.toml
-    confy::load_path(&path)
-        .with_context(|| format!("Error in loading or creating config file at {:?}", path))
+    run_mgmt(args)
 }


### PR DESCRIPTION
Relates to issue #56 

Some system paths and user ones are added if program runs on Linux. 

Added explanation for searching configuration location to README.
Added command to generate default configuration.
Added dependency "toml" to produce toml configuration file without confy. 
Added dependency "dirs" for retrieving home folde.
Adjusted changelog.